### PR TITLE
Reset the towstring() char pointer before converting

### DIFF
--- a/c++/namegen.cc
+++ b/c++/namegen.cc
@@ -506,6 +506,7 @@ std::wstring towstring(const std::string & s)
 	}
 
 	std::vector<wchar_t> buf(wn);
+	cs = s.c_str();
 	const size_t wn_again = std::mbsrtowcs(buf.data(), &cs, wn, nullptr);
 
 	if (wn_again == static_cast<size_t>(-1)) {


### PR DESCRIPTION
In mbsrtowcs(), when dst is a null pointer then src must be left
unchanged (ISO/IEC 9899:1999 7.24.6.4.1-3). However, Mingw-w64 advances
src when dst is a null pointer, which is a bug. As a workaround, reset
src back to the beginning of the input. This fixes #10.